### PR TITLE
Changed z-index for .post-meta

### DIFF
--- a/css/main.sass
+++ b/css/main.sass
@@ -252,7 +252,7 @@ body
       bottom: $rs*5
       left: 30%
       right: 30%
-      z-index: 999
+      z-index: 9
       font-family: $font-sans
       @include box-sizing(border-box)
       @include respond-to(800)


### PR DESCRIPTION
Changed **z-index** for `.post-meta` on `.post` `.article-image` in order to be
under `.logo-readium` in certain cases (on mobile devices)
