### PR TITLE
Use post.excerpt as summary and add DISGUS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Main settings for the site
 * **email**: mail address of the site owner
 * **author**: author name
 * **author_image**: small image of author (300x * 300px)
-
+* **disqus**: add a disqus forum for your post
 
 ### Social
 

--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,8 @@ paginate:	5
 url: "http://myblog.***.***" # the base hostname & protocol for your site
 baseurl: ""
 
-#fill in disgus shortname to use disgus
-#disgus: disgus-shortname
+#fill in disqus shortname to use disqus
+#disqus: disqus-shortname
 
 # social icons and sharing options
 social:

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,9 @@ paginate:	5
 url: "http://myblog.***.***" # the base hostname & protocol for your site
 baseurl: ""
 
+#fill in disgus shortname to use disgus
+#disgus: disgus-shortname
+
 # social icons and sharing options
 social:
   - icon:	twitter

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-  <meta name="description" content="{{ site.description }}" />
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt }}{% else %}{{ site.description }}{% endif %}" />
 
   <meta name="HandheldFriendly" content="True" />
   <meta name="MobileOptimized" content="320" />

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -85,11 +85,11 @@
             </footer>
           </div>
         </div>
-        {%if site.disgus %}
+        {%if site.disqus %}
         <div id="disqus_thread"></div>
         <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-            var disqus_shortname = '{{site.disgus}}'; // required: replace example with your forum shortname
+            var disqus_shortname = '{{site.disqus}}'; // required: replace example with your forum shortname
 
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -85,6 +85,21 @@
             </footer>
           </div>
         </div>
+        {%if site.disgus %}
+        <div id="disqus_thread"></div>
+        <script type="text/javascript">
+            /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+            var disqus_shortname = '{{site.disgus}}'; // required: replace example with your forum shortname
+
+            /* * * DON'T EDIT BELOW THIS LINE * * */
+            (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
+        </script>
+        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+        {% endif %}
       </article>
     </main>
     <div class="bottom-closer">

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ layout: default
               <h2 class="post-title" itemprop="name"><a href="{{ post.url }}" itemprop="url">{{ post.title }}</a></h2>
             </header>
             <section class="post-excerpt" itemprop="description">
-              <p>{{ post.content | strip_html | truncatewords: 50 }}</p>
+              <p>{{ post.excerpt | strip_html | truncatewords: 50 }}</p>
             </section>
             <div class="post-meta">
               <time datetime="{{ post.date | date_to_long_string }}">{{ post.date | date_to_long_string }}</time>


### PR DESCRIPTION
For better SEO and more flexibility
Changed to use [Post excerpts](http://jekyllrb.com/docs/posts/#post-excerpts) in the **description meta-tag**
Index.html also use post exceprt as post summary
So users can customize excerpt on front matter and it will be reflected on index and SEO


Also add a new config parameter: **disgus**
site with this parameter will try to load and display disgus at the end of post

