### PR TITLE
remove protocol from brick fonts href, this fixes mixed content error

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
 
   <link rel="shortcut icon" href="{{ "/assets/images/favicon.ico" | prepend: site.baseurl }}">
 <!--  <link rel="stylesheet" href="{{asset "js/styles/obsidian.css"}}"> -->
-  <link rel="stylesheet" href="http://brick.a.ssl.fastly.net/Linux+Libertine:400,400i,700,700i/Open+Sans:400,400i,700,700i">
+  <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Linux+Libertine:400,400i,700,700i/Open+Sans:400,400i,700,700i">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{ "/css/main.css"  | prepend: site.baseurl  }}" />


### PR DESCRIPTION
this fixes a `mixed content error` when using the theme on a https domain