### PR TITLE
Added 'https' protocol to Facebook share URL.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ social:
 #  - icon:	facebook
 #    url:	https://facebook.com/???
 #    desc: Connect with me facebook
-#    share_url: //www.facebook.com/sharer.php
+#    share_url: https://www.facebook.com/sharer.php
 #    share_title: ?t=
 #    share_link: "&amp;u="
 


### PR DESCRIPTION
The Facebook share URL did not have an explicit protocol prefix. "https:" was added to remedy this.