### PR TITLE
$(window).focus in Chrome only fires if the window

### DIFF
--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -10,7 +10,6 @@
     var $window = $(window),
     $image = $('.post-image-image, .teaserimage-image');
     
-    $window.on('focus', function(){
       $window.on('scroll', function() {
         var top = $window.scrollTop();
 
@@ -35,7 +34,6 @@
           }
         }
       });
-    });
 
   });
 }(jQuery));


### PR DESCRIPTION
had lost focus before and regains it after. That means
it won't fire when the site loads for the first time.