### PR TITLE
Add hover title element to icons in the about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ layout: default
     <div class="custom-links">
       {% for social in site.social %}
         {% if social.url %}
-            <a class="icon-{{ social.icon }}" href="{{ social.url }}">
+            <a class="icon-{{ social.icon }}" href="{{ social.url }}" {% if social.desc %} title="{{ social.desc }}"{% endif %}">
               <i class="fa fa-{{ social.icon }}"></i>
             </a>
             &nbsp;&nbsp;·&nbsp;&nbsp;


### PR DESCRIPTION
This PR adds the title element to the links found in the social icons section (see this screenshot)
![screenshot 2015-08-18 18 39 35](https://cloud.githubusercontent.com/assets/882850/9344715/a65e533e-45d8-11e5-88b1-d437dd29c277.png)
So if you set a description it will be presented as a hover element.
