### PR TITLE
Add opengraph (facebook) meta tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,11 +12,22 @@
   <meta name="MobileOptimized" content="320" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  
+  <meta property="og:site_name" content="{{ site.title }}" />
+  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}"/>
+  {% if page.excerpt %}
+  <meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}" />
+  {% elsif site.description %}
+  <meta property="og:description" content="{{ site.description | strip_html | strip_newlines | truncate: 200 }}" />
+  {% endif %}
+  <meta property="og:image" content="{% if page.image %}{{ page.image }}{% else %}{{ site.logo }}{% endif %}" />
+  <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" >
+  <meta property="og:type" content="blog" />
+  {% if page.date %}<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">{% endif %}
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
   <link rel="shortcut icon" href="{{ "/assets/images/favicon.ico" | prepend: site.baseurl }}">
-<!--  <link rel="stylesheet" href="{{asset "js/styles/obsidian.css"}}"> -->
   <link rel="stylesheet" href="http://brick.a.ssl.fastly.net/Linux+Libertine:400,400i,700,700i/Open+Sans:400,400i,700,700i">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,7 +20,7 @@
   {% elsif site.description %}
   <meta property="og:description" content="{{ site.description | strip_html | strip_newlines | truncate: 200 }}" />
   {% endif %}
-  <meta property="og:image" content="{% if page.image %}{{ page.image }}{% else %}{{ site.logo }}{% endif %}" />
+  <meta property="og:image" content="{% if page.image %}{{ page.image | prepend: site.url }}{% else %}{{ site.logo | prepend: site.url }}{% endif %}" />
   <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" >
   <meta property="og:type" content="blog" />
   {% if page.date %}<meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">{% endif %}


### PR DESCRIPTION
This PR adds the meta tags needed for social networks to generate a nice preview (this is what it looks like when I share a post from my blog on facebook)
![screenshot 2015-08-19 23 37 01](https://cloud.githubusercontent.com/assets/882850/9375181/902ce76c-46cb-11e5-9e6d-79b72593eb97.png)

I don't know if you want to support this enhancement so feel free to reject.  I am just offering it up.