### PR TITLE
adding twitter cards

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ paginate:	5
 
 url: "http://myblog.***.***" # the base hostname & protocol for your site
 baseurl: ""
+#used to display twitter cards
+twitter_handle: '@dirkfabisch'
 
 #fill in disqus shortname to use disqus
 #disqus: disqus-shortname

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,17 @@
   <meta name="MobileOptimized" content="320" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  {% if site.twitter_handle %}
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="{{ site.twitter_handle }}" />
+    <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
+    <meta name="twitter:image" content="{{ site.logo | prepend: site.url }}" />
+    {% if page.excerpt %}
+    <meta name="twitter:description"  content="{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}" />
+    {% elsif site.description %}
+    <meta name="twitter:description" content="{{ site.description | strip_html | strip_newlines | truncate: 200 }}" />
+    {% endif %}
+  {% endif %}
   
   <meta property="og:site_name" content="{{ site.title }}" />
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}"/>


### PR DESCRIPTION
Similar to the facebook tags, twitter has a way to display a summary of your blog post any time someone links to it from within a tweet.  See here for an example:
![screenshot 2015-08-21 13 28 20](https://cloud.githubusercontent.com/assets/882850/9414827/59662222-4809-11e5-805f-e971fa1ddf68.png)
