### PR TITLE
Fix typo in MIT License URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See [_config.yml](https://github.com/dirkfabisch/mediator/blob/master/_config.ym
 Licensing
 ---------
 
-[MIT](https://github.com/dirkfabisch/madiator/blob/master/LICENSE) with no added caveats, so feel free to use this on your site without linking back to me or using a disclaimer or anything silly like that.
+[MIT](https://github.com/dirkfabisch/mediator/blob/master/LICENCE) with no added caveats, so feel free to use this on your site without linking back to me or using a disclaimer or anything silly like that.
 
 Contact
 -------


### PR DESCRIPTION
The URL in README.md is broken. This commit fixes it.