### PR TITLE
Downgrade Celluloid Requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     bourbon (4.2.3)
       sass (~> 3.4)
       thor
-    celluloid (0.16.1)
+    celluloid (0.16.0)
       timers (~> 4.0.0)
     classifier-reborn (2.0.3)
       fast-stemmer (~> 1.0)


### PR DESCRIPTION
Celluloid (0.16.1) has been yanked from Rubygems, so the build failed when I tried to run it. Downgrading to 0.16.0 seemed to do fine, as is required elsewhere in the lock file.