### PR TITLE
Fix typo in 'Welcome to Jekyll' post

### DIFF
--- a/_posts/2014-08-29-welcome-to-jekyll.markdown
+++ b/_posts/2014-08-29-welcome-to-jekyll.markdown
@@ -4,7 +4,7 @@ title:  "Welcome to Jekyll!"
 date:   2014-08-29 14:34:25
 categories: jekyll update
 tags: featured
-image: /assets/article_images/2014-08-29-welcome-to-jekyll/desktop.jpg
+image: /assets/article_images/2014-08-29-welcome-to-jekyll/desktop.JPG
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve --watch`, which launches a web server and auto-regenerates your site when a file is updated.
 


### PR DESCRIPTION
Header image is desktop.JPG, not desktop.jpg.